### PR TITLE
Migrate to DSS Python 0.10

### DIFF
--- a/opendssdirect/Basic.py
+++ b/opendssdirect/Basic.py
@@ -72,9 +72,16 @@ def Version():
     return get_string(lib.DSS_Get_Version())
 
 
-def AllowForms(value=None):
-    # warnings.warn('AllowForms is not implemented.')
-    return 1
+def AllowForms(*args):
+    """Gets/sets whether text output is allowed"""
+    
+    # Getter
+    if len(args) == 0:
+        return lib.DSS_Get_AllowForms() != 0
+
+    # Setter
+    Value, = args
+    lib.DSS_Set_AllowForms(Value)
 
 
 def ShowPanel():

--- a/opendssdirect/_utils.py
+++ b/opendssdirect/_utils.py
@@ -4,15 +4,15 @@ from __future__ import absolute_import
 # Import dss_python, exposing only OpenDSS v7 while v8 is still considered
 # experimental (at least with Free Pascal)
 import dss as dss_py
-from dss._cffi_api_util import CffiApiUtil, codec
-from dss.v7.dss_capi import CheckForError
 import numpy as np
 import warnings
 
 # Bind to the FFI module instance
-lib = dss_py._dss_capi_v7.lib
-ffi = dss_py._dss_capi_v7.ffi
-api_util = CffiApiUtil(ffi, lib)
+lib = dss_py.v7.api_util.lib
+ffi = dss_py.v7.api_util.ffi
+api_util = dss_py.v7.api_util
+codec = api_util.codec
+CheckForError = dss_py.v7.DSS.CheckForError
 
 # Currently, we prefer the functions that return lists (suffix 2)
 # to keep higher compatibility with previous versions of OpenDSSDirect.py.

--- a/opendssdirect/_version.py
+++ b/opendssdirect/_version.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     author_email="dheepak.krishnamurthy@nrel.gov",
     license="BSD-compatible",
     packages=find_packages(),
-    install_requires=["future", "six", "dss_python>=0.9.8"],
+    install_requires=["future", "six", "dss_python>=0.10.0"],
     extras_require={
         "extras": ["pandas", "matplotlib", "networkx"],
         "dev": [
@@ -78,6 +78,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     cmdclass={"develop": PostDevelopCommand},
 )

--- a/tests/test_opendssdirect.py
+++ b/tests/test_opendssdirect.py
@@ -279,6 +279,8 @@ def test_13Node_Basic(dss):
         u"UPFCControl",
         u"ESPVLControl",
         u"IndMach012",
+        u"GICsource",
+        u"AutoTrans",
         u"InvControl",
         u"ExpControl",
         u"GICLine",
@@ -288,7 +290,7 @@ def test_13Node_Basic(dss):
         u"EnergyMeter",
         u"Sensor",
     ]
-    assert dss.Basic.NumClasses() == 47
+    assert dss.Basic.NumClasses() == 49
     assert dss.Basic.ShowPanel() == 0
     assert dss.Basic.ClearAll() is None
     assert os.path.abspath(dss.Basic.DataPath()) == os.path.abspath(".")

--- a/tests/test_opendssdirect.py
+++ b/tests/test_opendssdirect.py
@@ -198,8 +198,19 @@ def test_configuration():
 
     import opendssdirect as dss
 
-    assert dss.Basic.AllowForms() == 1, "Allow forms should be disabled"
+    # Test toggling the console output using AllowForms.
+    # Note COM's AllowForms can only be disabled and it ignores
+    # the user's command to reallow forms if they were previously
+    # disabled.
+    assert dss.Basic.AllowForms() == False, "Allow forms should be disabled by default"
+    
+    dss.Basic.AllowForms(True)
+    assert dss.Basic.AllowForms() == True
 
+    dss.Basic.AllowForms(False)
+    assert dss.Basic.AllowForms() == False
+
+    
 
 def test_13Node(dss):
 
@@ -227,7 +238,7 @@ def test_13Node(dss):
 
 def test_13Node_Basic(dss):
 
-    assert dss.Basic.AllowForms() == 1
+    assert dss.Basic.AllowForms() == False
     assert dss.Basic.Classes() == [
         u"Solution",
         u"LineCode",


### PR DESCRIPTION
This integrates with DSS Python 0.10.0 (just released). 

Closes #32, #36, #39.